### PR TITLE
42 account info flows

### DIFF
--- a/workflows/src/main/kotlin/com/r3/corda/lib/accounts/workflows/flows/AccountInfoByKey.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/accounts/workflows/flows/AccountInfoByKey.kt
@@ -1,0 +1,18 @@
+package com.r3.corda.lib.accounts.workflows.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.lib.accounts.contracts.states.AccountInfo
+import com.r3.corda.lib.accounts.workflows.accountService
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import java.security.PublicKey
+
+@StartableByRPC
+class AccountInfoByKey(private val owningKey: PublicKey) : FlowLogic<StateAndRef<AccountInfo>?>() {
+
+    @Suspendable
+    override fun call(): StateAndRef<AccountInfo>? {
+        return accountService.accountInfo(owningKey)
+    }
+}

--- a/workflows/src/main/kotlin/com/r3/corda/lib/accounts/workflows/flows/AccountInfoByName.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/accounts/workflows/flows/AccountInfoByName.kt
@@ -1,0 +1,17 @@
+package com.r3.corda.lib.accounts.workflows.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.lib.accounts.contracts.states.AccountInfo
+import com.r3.corda.lib.accounts.workflows.accountService
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+
+@StartableByRPC
+class AccountInfoByName(private val name: String) : FlowLogic<StateAndRef<AccountInfo>?>() {
+
+    @Suspendable
+    override fun call(): StateAndRef<AccountInfo>? {
+        return accountService.accountInfo(name)
+    }
+}

--- a/workflows/src/main/kotlin/com/r3/corda/lib/accounts/workflows/flows/AccountInfoByUUID.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/accounts/workflows/flows/AccountInfoByUUID.kt
@@ -1,0 +1,18 @@
+package com.r3.corda.lib.accounts.workflows.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.lib.accounts.contracts.states.AccountInfo
+import com.r3.corda.lib.accounts.workflows.accountService
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import java.util.*
+
+@StartableByRPC
+class AccountInfoByUUID(private val uuid: UUID) : FlowLogic<StateAndRef<AccountInfo>?>() {
+
+    @Suspendable
+    override fun call(): StateAndRef<AccountInfo>? {
+        return accountService.accountInfo(uuid)
+    }
+}

--- a/workflows/src/test/kotlin/com/r3/corda/lib/accounts/workflows/test/AccountInfoTests.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/accounts/workflows/test/AccountInfoTests.kt
@@ -1,6 +1,7 @@
 package com.r3.corda.lib.accounts.workflows.test
 
 import com.r3.corda.lib.accounts.contracts.states.AccountInfo
+import com.r3.corda.lib.accounts.workflows.flows.AccountInfoByName
 import com.r3.corda.lib.accounts.workflows.flows.AccountInfoByUUID
 
 import com.r3.corda.lib.accounts.workflows.flows.CreateAccount
@@ -83,4 +84,16 @@ class AccountInfoTests {
         Assert.assertNull(accountInfoCfromA)
     }
 
+    @Test
+    fun `Get accounts by Name`() {
+        val accountInfoAfromA = nodeA.startFlow(AccountInfoByName(accountOnNodeA.state.data.name)).runAndGet(network)
+        val accountInfoBfromA = nodeA.startFlow(AccountInfoByName(accountOnNodeB.state.data.name)).runAndGet(network)
+        Assert.assertEquals(accountOnNodeA, accountInfoAfromA)
+        Assert.assertEquals(accountOnNodeB, accountInfoBfromA)
+
+        val accountInfoAfromB = nodeB.startFlow(AccountInfoByName(accountOnNodeA.state.data.name)).runAndGet(network)
+        val accountInfoBfromB = nodeB.startFlow(AccountInfoByName(accountOnNodeB.state.data.name)).runAndGet(network)
+        Assert.assertEquals(accountOnNodeA, accountInfoAfromB)
+        Assert.assertEquals(accountOnNodeB, accountInfoBfromB)
+    }
 }

--- a/workflows/src/test/kotlin/com/r3/corda/lib/accounts/workflows/test/AccountInfoTests.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/accounts/workflows/test/AccountInfoTests.kt
@@ -1,10 +1,12 @@
 package com.r3.corda.lib.accounts.workflows.test
 
 import com.r3.corda.lib.accounts.contracts.states.AccountInfo
+import com.r3.corda.lib.accounts.workflows.flows.AccountInfoByKey
 import com.r3.corda.lib.accounts.workflows.flows.AccountInfoByName
 import com.r3.corda.lib.accounts.workflows.flows.AccountInfoByUUID
 
 import com.r3.corda.lib.accounts.workflows.flows.CreateAccount
+import com.r3.corda.lib.accounts.workflows.flows.RequestKeyForAccount
 import com.r3.corda.lib.accounts.workflows.flows.ShareAccountInfo
 import net.corda.core.contracts.StateAndRef
 import net.corda.testing.common.internal.testNetworkParameters
@@ -96,4 +98,18 @@ class AccountInfoTests {
         Assert.assertEquals(accountOnNodeA, accountInfoAfromB)
         Assert.assertEquals(accountOnNodeB, accountInfoBfromB)
     }
+
+    @Test
+    fun `Get accounts by PublicKey`() {
+        val keyA = nodeA.startFlow(RequestKeyForAccount(accountOnNodeA.state.data)).runAndGet(network).owningKey
+
+        val accountInfoOnA = nodeA.startFlow(AccountInfoByKey(keyA)).runAndGet(network)
+        Assert.assertEquals(accountOnNodeA, accountInfoOnA)
+
+        //Note that we deliberately get the key from node A then do the lookup on Node B
+        val keyB = nodeA.startFlow(RequestKeyForAccount(accountOnNodeB.state.data)).runAndGet(network).owningKey
+        val accountInfoOnB = nodeB.startFlow(AccountInfoByKey(keyB)).runAndGet(network)
+        Assert.assertEquals(accountOnNodeB, accountInfoOnB)
+    }
+
 }


### PR DESCRIPTION
Resolve #42 by adding 3 new flows that enable the AccountService.accountInfo functions to be called over RPC.