### PR TITLE
ES-2458: 4.12 GA post release actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,13 @@ import static org.gradle.api.JavaVersion.VERSION_17
 buildscript {
     ext {
         accounts_release_group = 'com.r3.corda.lib.accounts'
-        accounts_release_version = '1.1-RC02'
+        accounts_release_version = '1.1'
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12-RC02'
+        corda_release_version = '4.12'
         tokens_release_group = 'com.r3.corda.lib.tokens'
-        tokens_release_version = '1.3-RC02'
+        tokens_release_version = '1.3'
         confidential_id_release_group = "com.r3.corda.lib.ci"
-        confidential_id_release_version = "1.2-RC02"
+        confidential_id_release_version = "1.2"
 
         corda_gradle_plugins_version = '5.1.1'
         mavenVersion = '3.1.0'


### PR DESCRIPTION
Post Release actions - Pin internal dependencies to GA versions. Please note these versions have already been released via tag creation but this PR is now committing the needed changes back to the release branch.