### PR TITLE
ENT-12080 jcenter retirement (#126)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,10 @@ buildscript {
     }
 
     repositories {
-        jcenter()
         mavenCentral()
         maven { url "${publicArtifactURL}/corda-releases" }
+        // as last resort, check our backup of now defunc JCenter repo
+        maven { url "${publicArtifactURL}/jcenter-backup" }
     }
 
     dependencies {
@@ -80,7 +81,6 @@ subprojects {
 
     repositories {
         mavenLocal()
-        jcenter()
         mavenCentral()
         maven {
             url "${publicArtifactURL}/corda-releases"
@@ -111,6 +111,8 @@ subprojects {
         }
         maven { url "https://repo.gradle.org/gradle/libs-releases-local" }
         maven { url 'https://jitpack.io' }
+        // as last resort, check our backup of now defunc JCenter repo
+        maven { url "${publicArtifactURL}/jcenter-backup" }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/examples/gold-trading/cordapp/src/test/kotlin/net/corda/gold/test/WebPermissionTests.kt
+++ b/examples/gold-trading/cordapp/src/test/kotlin/net/corda/gold/test/WebPermissionTests.kt
@@ -1,5 +1,6 @@
 package net.corda.gold.test
 
+import net.corda.core.node.NetworkParameters
 import net.corda.core.utilities.getOrThrow
 import net.corda.gold.trading.workflows.flows.GetAllWebUsersFlow
 import net.corda.gold.trading.workflows.flows.NewWebAccountFlow
@@ -24,14 +25,14 @@ class WebPermissionTests {
 
     @Before
     fun setup() {
-        network = MockNetwork(
-            listOf("net.corda.gold.trading", "com.r3.corda.lib.accounts"),
-            MockNetworkParameters(
-                networkParameters = testNetworkParameters(
-                    minimumPlatformVersion = 4
-                )
-            )
-        )
+        network = MockNetwork(MockNetworkParameters(
+            networkParameters = testNetworkParameters(
+                    minimumPlatformVersion = 4),
+            cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.gold.trading"),
+                TestCordapp.findCordapp("com.r3.corda.lib.accounts.contracts"),
+                TestCordapp.findCordapp("com.r3.corda.lib.accounts.workflows"))
+
+        ))
         a = network.createPartyNode()
 
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,6 @@ include 'examples:gold-trading:agent'
 include 'examples:gold-trading:fund-admin'
 include 'examples:gold-trading:fund-manager'
 include 'examples:tokens-integration-test'
-include 'freighter-tests'
+//include 'freighter-tests'
 
 


### PR DESCRIPTION
* ENT-12080 jcenter retirement

* ENT-12080: Upgraded artifactory plugin version to 4.16.1.

* moved JCenter backup repo to end of the list of repositories

* ENT-12080 Fix broken test

* ENT-12080 Use mirror of artifactory for freighter

* ENT-12080 Disable freighter tests as freighter is broken

* ENT-12080 Disable freighter tests as freighter is broken

---------

Co-authored-by: Adel El-Beik <adel.el-beik@r3.com>
Co-authored-by: Waldemar Zurowski <waldemar.zurowski@r3.com>

(cherry picked from commit e6ff361749ea3886f654cf7fe6aa813f0c3a23cb)