### PR TITLE
ENT-12854 - Escrow build support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven { url "${publicArtifactURL}/corda-releases" }
         // as last resort, check our backup of now defunc JCenter repo
@@ -174,7 +175,9 @@ configure(publishProjects) { subproject ->
         from javadoc.destinationDir
     }
 
-    task install(dependsOn: 'publishToMavenLocal')
+    if (System.getenv("R3_EXTERNAL") != "1") {
+        task install(dependsOn: 'publishToMavenLocal')
+    }
 
     publishing {
         publications {


### PR DESCRIPTION
Made some of the build code optional, based on the presence of an R3_EXTERNAL environment variable.
This is to support builds by developers outside of R3, using the escrow archive of Corda Enterprise.