### PR TITLE
ENT-12854 - Updated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,18 +5,18 @@ buildscript {
         accounts_release_group = 'com.r3.corda.lib.accounts'
         accounts_release_version = '1.1'
         corda_release_group = 'net.corda'
-        corda_release_version = '4.12'
+        corda_release_version = '4.12.5'
         tokens_release_group = 'com.r3.corda.lib.tokens'
-        tokens_release_version = '1.3'
+        tokens_release_version = '1.3.2'
         confidential_id_release_group = "com.r3.corda.lib.ci"
-        confidential_id_release_version = "1.2"
+        confidential_id_release_version = "1.2.7"
 
-        corda_gradle_plugins_version = '5.1.1'
+        corda_gradle_plugins_version = '5.1.3'
         mavenVersion = '3.1.0'
         maven_resolver_version = "1.1.1"
         kotlin_version = '1.9.0'
         junit_version = '4.12'
-        quasar_version = '0.9.0_r3'
+        quasar_version = '0.9.1_r3'
         log4j_version = '2.23.1'
         spring_boot_version = '3.1.2'
         hibernate_version = '5.6.14.Final'


### PR DESCRIPTION
Update to depend on the latest R3 plugins and libraries.
The latest R3 plugins and libraries can be built outside of R3. In order for accounts to also be built outside of R3 it must depend on those latest versions.